### PR TITLE
style: apply apple-inspired dark theme

### DIFF
--- a/first/style.css
+++ b/first/style.css
@@ -4,22 +4,27 @@
     padding: 0;
     margin: 0;
     box-sizing: border-box;
-    font-family: "Montserrat", sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Montserrat", sans-serif;
     transition: all 0.3s ease-in-out;
 }
 
 :root {
-    --blueColor: #05388b;
-    --lghblueColor: #bfd0ec;
-    --whiteColor: #fff;
-    --txtblColor: #0f005b;
-    --gray: #8ca1c4;
+    --blueColor: #0a84ff;
+    --lghblueColor: #64d2ff;
+    --whiteColor: #1c1c1e;
+    --txtblColor: #f2f2f7;
+    --gray: #8e8e93;
     --brRad: 50px;
     --success: #47c129;
     --warn: #fff73c;
     --danger: #b02b0d;
-    --alpgaGray: #bfd0ec4d;
-    --alphaColor: #8ca1c4;
+    --alpgaGray: #8e8e934d;
+    --alphaColor: #8e8e93;
+}
+
+body {
+    background-color: var(--whiteColor);
+    color: var(--txtblColor);
 }
 
 

--- a/second/style.css
+++ b/second/style.css
@@ -1,3 +1,17 @@
+:root {
+    --background: #1c1c1e;
+    --surface: #2c2c2e;
+    --text: #f2f2f7;
+    --accent: #0a84ff;
+    --gray: #3a3a3c;
+}
+
+body {
+    background-color: var(--background);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Montserrat", sans-serif;
+}
+
 .container {
     max-width: 393px;
     margin: 0 auto;
@@ -18,7 +32,7 @@
     align-items: center;
     justify-content: space-evenly;
     box-shadow: 2px 4px 7px 1px #00000040;
-    background-color: #fff;
+    background-color: var(--surface);
     border-radius: 10px;
 }
 
@@ -39,7 +53,7 @@
 }
 
 .navigetion__item svg.active {
-    stroke: #1a73e8;
+    stroke: var(--accent);
 }
 
 .user {
@@ -57,7 +71,7 @@
 }
 
 .filter {
-    border-top: 3px solid #1a73e8;
+    border-top: 3px solid var(--accent);
     border-radius: 30px 30px 0px 0px;
     padding: 30px 25px 70px;
 }
@@ -81,7 +95,7 @@
     line-height: 22px;
     text-align: center;
     text-decoration: underline;
-    color: #1a73e8;
+    color: var(--accent);
     text-underline-position: from-font;
     text-decoration-skip-ink: none;
 }
@@ -94,8 +108,10 @@
     select {
         border-radius: 30px;
         height: 35px;
-        border: 1px solid #F5F5F5;
+        border: 1px solid var(--gray);
         padding: 0 10px;
+        background-color: var(--surface);
+        color: var(--text);
     }
 
     .from-to {
@@ -113,11 +129,13 @@
         align-items: center;
 
         input {
-            border: 1px solid #F5F5F5;
+            border: 1px solid var(--gray);
             border-radius: 30px;
             height: 35px;
             width: 110px;
             padding: 0 7px;
+            background-color: var(--surface);
+            color: var(--text);
         }
     }
 }
@@ -131,10 +149,13 @@
     justify-content: center;
     text-align: center;
     height: 16px;
+    border: 1px solid var(--gray);
+    background-color: var(--surface);
+    color: var(--text);
 }
 
 :range {
-    color: black;
+    color: var(--text);
 }
 
  

--- a/second/styleInfo.css
+++ b/second/styleInfo.css
@@ -3,7 +3,7 @@
 * {
     padding: 0;
     margin: 0;
-    font-family: "Montserrat", sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Montserrat", sans-serif;
     box-sizing: border-box;
 }
 
@@ -31,32 +31,37 @@ nav {
 }
 
 :root {
-    --whiteMiniCard: #FFF;
-    --darkhomeDistance: #4929B3;
-    --homeDistance: #00ced142;
-    --homeDistanceBor: #00CED1;
-    --darkhomeDistance2: #4929b359;
-    --homeDistance2: #1a73e85a;
-    --homeDistanceBor2: #1A73E8;
-    --blueColor: #1a73e8;
-    --blueColor2: #0088cc;
-    --border-color: #00ced1;
-    --darkBrColor: #EAE9FF;
-    --whiteColor: #fff;
-    --txtblColor: #0f005b;
-    --gray: #464567;
+    --whiteMiniCard: #1c1c1e;
+    --darkhomeDistance: #0a84ff;
+    --homeDistance: #64d2ff33;
+    --homeDistanceBor: #0a84ff;
+    --darkhomeDistance2: #0a84ff4d;
+    --homeDistance2: #0a84ff4d;
+    --homeDistanceBor2: #0a84ff;
+    --blueColor: #0a84ff;
+    --blueColor2: #64d2ff;
+    --border-color: #0a84ff;
+    --darkBrColor: #2c2c2e;
+    --whiteColor: #1c1c1e;
+    --txtblColor: #f2f2f7;
+    --gray: #8e8e93;
     --brRad: 50px;
     --success: #32CD32;
     --warn: #fff73c;
     --danger: #ff4c4c;
-    --alpgaGray: #bfd0ec4d;
-    --alphaColor: #8ca1c4;
-    --orange: #FF9900;
-    --dardMode: #05052B;
-    --darkDz1: #4929B3;
-    --iconColor: #A9A9A9;
-    --closers: #05052B;
-    --activeIconDouble: #1A73E8;
+    --alpgaGray: #8e8e9333;
+    --alphaColor: #8e8e93;
+    --orange: #ff9f0a;
+    --dardMode: #1c1c1e;
+    --darkDz1: #0a84ff;
+    --iconColor: #8e8e93;
+    --closers: #1c1c1e;
+    --activeIconDouble: #0a84ff;
+}
+
+body {
+    background-color: var(--whiteColor);
+    color: var(--txtblColor);
 }
 
 .alert {


### PR DESCRIPTION
## Summary
- adopt Apple system fonts and dark color variables for both interfaces
- update navigation, filters and form elements to use accent blue on dark backgrounds

## Testing
- `npm test` (fails: no package.json)


------
https://chatgpt.com/codex/tasks/task_e_689db13c9a30832e9859c0b9b7b58269